### PR TITLE
Remove additional linefeed from sub-command cat

### DIFF
--- a/there/__main__.py
+++ b/there/__main__.py
@@ -152,7 +152,6 @@ def command_cat(user, m, args):
     Print the contents of a file from the target to stdout.
     """
     user.output_binary(m.read_from_file(args.PATH))
-    user.output_binary(b'\n')
 
 
 def command_rm(user, m, args):


### PR DESCRIPTION
It is unexpected that a file gets bigger after "there push myfile /flash ; there cat /flash/myfile >myfile".
Original Unix cat does not add a linefeed either, and this tool seems to mimic Unix commands.
