### PR TITLE
Bigger faster transfers

### DIFF
--- a/there/repl_connection.py
+++ b/there/repl_connection.py
@@ -261,11 +261,11 @@ class MicroPythonRepl(object):
         """
         if not isinstance(contents, (bytes, bytearray)):
             raise TypeError('contents must be bytes/bytearray, got {} instead'.format(type(contents)))
-        blocksize = 128
+        blocksize = 512
         self.exec('_f = open({!r}, "wb")'.format(str(path)))
         for i in range(0, len(contents), blocksize):
             self.exec('_f.write({!r})'.format(contents[i:i+blocksize]))
-        self.exec('_f.close(); del _f;')
+        self.exec('_f.close(); del _f')
 
     def truncate(self, path, length):
         return self.evaluate(

--- a/there/repl_connection.py
+++ b/there/repl_connection.py
@@ -19,6 +19,7 @@ REPL mode, so the current implementation is not generic for any Python REPL!
 import ast
 import fnmatch
 import queue
+import io
 import os
 import posixpath
 import re
@@ -176,13 +177,13 @@ class MicroPythonRepl(object):
         """
         return self.protocol.exec(*args, **kwargs)
 
-    def evaluate(self, string, timeout=3):
+    def evaluate(self, string):
         """
         Execute a string on the target and return its output parsed as python
         literal. Works for simple constructs such as numbers, lists,
         dictionaries.
         """
-        return ast.literal_eval(self.exec(string, timeout=timeout))
+        return ast.literal_eval(self.exec(string))
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -235,18 +236,25 @@ class MicroPythonRepl(object):
 
     def read_from_file(self, path):
         """Return the contents of a remote file as byte string"""
+        # reading (lines * linesize) must not take more than 1sec and 2K target RAM!
+        lines = max(1, self.serial.baudrate // 9600)
+        linesize = 512
         # use the fact that Python joins adjacent consecutive strings
-        # for the snippet here
-        blocksize = 512
-        return b''.join(self.evaluate(
+        # for the snippet here and for the remotely printed lines!
+        self.exec(
             '_f = open({!r}, "rb")\n'
-            'print("[")\n'
-            'while True:\n'
-            '    _b = _f.read({})\n'
-            '    if not _b: break\n'
-            '    print(_b, ",")\n'
-            'print("]")\n'
-            '_f.close(); del _f; del _b'.format(str(path), blocksize), timeout=60))
+            'def _b():\n'
+            '  print("(")\n'
+            '  for _ in range({}): print(_f.read({}))\n'
+            '  print(")")'.format(str(path), lines, linesize))
+        contents = b''
+        while True:
+            block = self.evaluate('_b()')
+            if not block:
+                break
+            contents += block
+        self.exec('_f.close(); del _f; del _b')
+        return contents
 
     def write_file(self, local_filename, path=None):
         """Copy a file from local to remote filesystem"""
@@ -261,10 +269,16 @@ class MicroPythonRepl(object):
         """
         if not isinstance(contents, (bytes, bytearray)):
             raise TypeError('contents must be bytes/bytearray, got {} instead'.format(type(contents)))
-        blocksize = 512
+        # writing (lines * linesize) must not take more than 1sec and 2K target RAM!
+        lines = max(1, min(16, self.serial.baudrate // 2400))
+        linesize = 128
         self.exec('_f = open({!r}, "wb")'.format(str(path)))
-        for i in range(0, len(contents), blocksize):
-            self.exec('_f.write({!r})'.format(contents[i:i+blocksize]))
+        with io.BytesIO(contents) as cfile:
+            while True:
+                byte_lines = [repr(cfile.read(linesize)) for _ in range(lines)]
+                self.exec('_f.write(\n' + '\n'.join(byte_lines) + ')')
+                if byte_lines[-1] == repr(b''):
+                    break
         self.exec('_f.close(); del _f')
 
     def truncate(self, path, length):

--- a/there/repl_connection.py
+++ b/there/repl_connection.py
@@ -264,7 +264,7 @@ class MicroPythonRepl(object):
         blocksize = 512
         self.exec('_f = open({!r}, "wb")'.format(str(path)))
         for i in range(0, len(contents), blocksize):
-            self.exec('_f.write({!r})'.format(contents[i:i+blocksize]), timeout=60)
+            self.exec('_f.write({!r})'.format(contents[i:i+blocksize]))
         self.exec('_f.close(); del _f')
 
     def truncate(self, path, length):

--- a/there/repl_connection.py
+++ b/there/repl_connection.py
@@ -237,15 +237,16 @@ class MicroPythonRepl(object):
         """Return the contents of a remote file as byte string"""
         # use the fact that Python joins adjacent consecutive strings
         # for the snippet here
+        blocksize = 512
         return b''.join(self.evaluate(
             '_f = open({!r}, "rb")\n'
             'print("[")\n'
             'while True:\n'
-            '    _b = _f.read()\n'
+            '    _b = _f.read({})\n'
             '    if not _b: break\n'
             '    print(_b, ",")\n'
             'print("]")\n'
-            '_f.close(); del _f; del _b'.format(str(path))))
+            '_f.close(); del _f; del _b'.format(str(path), blocksize)))
 
     def write_file(self, local_filename, path=None):
         """Copy a file from local to remote filesystem"""

--- a/there/repl_connection.py
+++ b/there/repl_connection.py
@@ -176,13 +176,13 @@ class MicroPythonRepl(object):
         """
         return self.protocol.exec(*args, **kwargs)
 
-    def evaluate(self, string):
+    def evaluate(self, string, timeout=3):
         """
         Execute a string on the target and return its output parsed as python
         literal. Works for simple constructs such as numbers, lists,
         dictionaries.
         """
-        return ast.literal_eval(self.exec(string))
+        return ast.literal_eval(self.exec(string, timeout=timeout))
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -246,7 +246,7 @@ class MicroPythonRepl(object):
             '    if not _b: break\n'
             '    print(_b, ",")\n'
             'print("]")\n'
-            '_f.close(); del _f; del _b'.format(str(path), blocksize)))
+            '_f.close(); del _f; del _b'.format(str(path), blocksize), timeout=60))
 
     def write_file(self, local_filename, path=None):
         """Copy a file from local to remote filesystem"""
@@ -264,7 +264,7 @@ class MicroPythonRepl(object):
         blocksize = 512
         self.exec('_f = open({!r}, "wb")'.format(str(path)))
         for i in range(0, len(contents), blocksize):
-            self.exec('_f.write({!r})'.format(contents[i:i+blocksize]))
+            self.exec('_f.write({!r})'.format(contents[i:i+blocksize]), timeout=60)
         self.exec('_f.close(); del _f')
 
     def truncate(self, path, length):


### PR DESCRIPTION
This branch improves write speed from 6kB/s to 11kB/s and read speed from 7kB/s to 15kB/s (using 230400 baud). It also fixes transfers of files bigger than target RAM. And it fixes timeouts during such big transfers (tested with files upto 600kB).

Increasing timeouts to 60 sec is a hack to still prevent scripts to hang forever. An interactive user will press CTRL+C earlier anyway. A final solution will have to detect if a transfer is running or not.