### PR TITLE
feat(push): During push increase level of messages, except "already up to date"

### DIFF
--- a/there/__main__.py
+++ b/there/__main__.py
@@ -298,12 +298,12 @@ def push_file(user, m, local_path, remote_path, dry_run, force):
     """
     if not dry_run:
         if force or m.checksum_local_file(local_path) != m.checksum_remote_file(remote_path):
-            user.info('{} -> {}\n'.format(local_path, remote_path))
+            user.notice('{} -> {}\n'.format(local_path, remote_path))
             m.write_file(local_path, remote_path)
         else:
             user.info('{}: already up to date\n'.format(remote_path))
     else:
-        user.info('dry run: {} -> {}\n'.format(local_path, remote_path))
+        user.notice('dry run: {} -> {}\n'.format(local_path, remote_path))
 
 
 def command_push(user, m, args):


### PR DESCRIPTION
Currently it is not easy to see what files are updated during push, but to suppress messages for files that are "already up to date". With this patch messages about updated files during push will be shown even without option --verbose, but message "already up to date" will be hidden.
During pull there are messages too even without option --verbose. This patch makes push behave more like pull.