### PR TITLE
Better feedback if connect fails

### DIFF
--- a/there/__main__.py
+++ b/there/__main__.py
@@ -83,7 +83,7 @@ def make_connection(user, args, port=None):
                                         user=args.user,
                                         password=args.password)
     m.protocol.verbose = args.verbose > 2
-    user.info('connected to {} {}\n'.format(m.serial.port, m.serial.baudrate))
+    user.notice('connected to {} {}\n'.format(m.serial.port, m.serial.baudrate))
     return m
 
 
@@ -440,7 +440,7 @@ def command_rtc(user, m, args):
         user.output_text('{:%Y-%m-%d %H:%M:%S.%f}\n'.format(t2))
         if not datetime.timedelta(seconds=0.9) <  t2 - t1 < datetime.timedelta(seconds=1.1):
             raise IOError('clock not running')
-        
+
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 def main():

--- a/there/repl_connection.py
+++ b/there/repl_connection.py
@@ -61,8 +61,13 @@ class MicroPythonReplProtocol(serial.threaded.Packetizer):
         self.response.put(data)
 
     def connection_lost(self, exc):
+        # FIXME: confusing TypeError if connection lost because port is already open by another process
+        # (TypeError: '>=' not supported between instances of 'SerialException' and 'int')
         if exc:
-            traceback.print_exc(exc)
+            if type(exc) is serial.SerialException:
+                sys.stderr.write(str(exc) + '\n')
+            else:
+                traceback.print_exc(exc)
         #~ sys.stderr.write('port closed\n')
 
     def _parse_error(self, text):
@@ -427,7 +432,7 @@ class MicroPythonRepl(object):
 
     def set_rtc(self, board_time=None):
         """Set the targets RTC from given datetime object"""
-        if board_time is None: 
+        if board_time is None:
             board_time = datetime.datetime.now()
         self.exec('import pyb; print(pyb.RTC().datetime(({0:%Y},{0:%m},{0:%d},{1},{0:%H},{0:%M},{0:%S},{2})))'.format(
             board_time,


### PR DESCRIPTION
This branch fixes a confusing TypeError if the port is already open by another process.

This is only a temporary quick & dirty solution until the real cause of the TypeError is fixed! Until then I check if connection is lost due to a SerialException and send its exception message to stderr. This message says: "read failed: device reports readiness to read but returned no data (device disconnected or multiple access on port?)"

The first commit increases the log level of message "connected to <port> <baud>" so that one "-v" is enough to show it.